### PR TITLE
Add CMakeLists.txt and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ build-MAC/
 build-ANDROID/
 build-IOS/
 build-UNIX/
-main.cpp
-/CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(eLogLib VERSION 0.1.0 LANGUAGES C CXX)
 
-file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS  "src/*.cpp")
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS  "libBuild/src/*.cpp")
 
 add_library(eLogLib SHARED ${SOURCE_FILES})
 target_compile_features(eLogLib PRIVATE cxx_std_20)
-target_include_directories(eLogLib PUBLIC hdr)
+target_include_directories(eLogLib PUBLIC libBuild/hdr)


### PR DESCRIPTION
This commit adds the CMakeLists.txt file and updates the .gitignore file to remove main.cpp and /CMakeLists.txt from tracking.